### PR TITLE
switch to signup page from login page

### DIFF
--- a/src/app/LoginUseCaseFactory.java
+++ b/src/app/LoginUseCaseFactory.java
@@ -6,6 +6,8 @@ import interface_adapter.login.LoginController;
 import interface_adapter.login.LoginPresenter;
 import interface_adapter.login.LoginViewModel;
 import interface_adapter.switch_view.SwitchViewController;
+import java.io.IOException;
+import javax.swing.*;
 import use_case.login.LoginInputBoundary;
 import use_case.login.LoginInteractor;
 import use_case.login.LoginOutputBoundary;
@@ -15,22 +17,20 @@ import use_case.switch_view.SwitchViewInteractor;
 import use_case.switch_view.SwitchViewOutputBoundary;
 import view.LoginView;
 
-import javax.swing.*;
-import java.io.IOException;
-
 public class LoginUseCaseFactory {
 
   /** Prevent instantiation. */
   private LoginUseCaseFactory() {}
 
   public static LoginView create(
-          ViewManagerModel viewManagerModel,
-          LoginViewModel loginViewModel,
-          LoggedInViewModel loggedInViewModel,
-          LoginUserDataAccessInterface userDataAccessObject) {
+      ViewManagerModel viewManagerModel,
+      LoginViewModel loginViewModel,
+      LoggedInViewModel loggedInViewModel,
+      LoginUserDataAccessInterface userDataAccessObject) {
 
     try {
-      LoginController loginController = createLoginController(
+      LoginController loginController =
+          createLoginController(
               viewManagerModel, loginViewModel, loggedInViewModel, userDataAccessObject);
 
       SwitchViewController switchViewController = createSwitchViewController(viewManagerModel);
@@ -43,24 +43,26 @@ public class LoginUseCaseFactory {
   }
 
   private static LoginController createLoginController(
-          ViewManagerModel viewManagerModel,
-          LoginViewModel loginViewModel,
-          LoggedInViewModel loggedInViewModel,
-          LoginUserDataAccessInterface userDataAccessObject) throws IOException {
+      ViewManagerModel viewManagerModel,
+      LoginViewModel loginViewModel,
+      LoggedInViewModel loggedInViewModel,
+      LoginUserDataAccessInterface userDataAccessObject)
+      throws IOException {
 
     LoginOutputBoundary loginOutputBoundary =
-            new LoginPresenter(viewManagerModel, loggedInViewModel, loginViewModel);
+        new LoginPresenter(viewManagerModel, loggedInViewModel, loginViewModel);
     LoginInputBoundary loginInteractor =
-            new LoginInteractor(userDataAccessObject, loginOutputBoundary);
+        new LoginInteractor(userDataAccessObject, loginOutputBoundary);
 
     return new LoginController(loginInteractor);
   }
 
-  private static SwitchViewController createSwitchViewController(ViewManagerModel viewManagerModel) {
+  private static SwitchViewController createSwitchViewController(
+      ViewManagerModel viewManagerModel) {
     SwitchViewOutputBoundary switchViewOutputBoundary =
-            (SwitchViewOutputBoundary) new LoginPresenter(viewManagerModel, null, null);
+        (SwitchViewOutputBoundary) new LoginPresenter(viewManagerModel, null, null);
     SwitchViewInputBoundary switchViewInteractor =
-            new SwitchViewInteractor(switchViewOutputBoundary);
+        new SwitchViewInteractor(switchViewOutputBoundary);
 
     return new SwitchViewController(switchViewInteractor);
   }

--- a/src/app/LoginUseCaseFactory.java
+++ b/src/app/LoginUseCaseFactory.java
@@ -16,7 +16,6 @@ import use_case.login.LoginUserDataAccessInterface;
 import use_case.switch_view.SwitchViewInputBoundary;
 import use_case.switch_view.SwitchViewInteractor;
 import use_case.switch_view.SwitchViewOutputBoundary;
-import use_case.switch_view.SwitchViewUserDataAccessInterface;
 import view.LoginView;
 
 public class LoginUseCaseFactory {
@@ -25,15 +24,15 @@ public class LoginUseCaseFactory {
   private LoginUseCaseFactory() {}
 
   public static LoginView create(
-          ViewManagerModel viewManagerModel,
-          LoginViewModel loginViewModel,
-          LoggedInViewModel loggedInViewModel,
-          LoginUserDataAccessInterface userDataAccessObject) {
+      ViewManagerModel viewManagerModel,
+      LoginViewModel loginViewModel,
+      LoggedInViewModel loggedInViewModel,
+      LoginUserDataAccessInterface userDataAccessObject) {
 
     try {
       LoginController loginController =
-              createLoginUseCase(
-                      viewManagerModel, loginViewModel, loggedInViewModel, userDataAccessObject);
+          createLoginUseCase(
+              viewManagerModel, loginViewModel, loggedInViewModel, userDataAccessObject);
       return new LoginView(loginViewModel, loginController);
     } catch (IOException e) {
       JOptionPane.showMessageDialog(null, "Could not open user data file.");
@@ -43,24 +42,25 @@ public class LoginUseCaseFactory {
   }
 
   private static LoginController createLoginUseCase(
-          ViewManagerModel viewManagerModel,
-          LoginViewModel loginViewModel,
-          LoggedInViewModel loggedInViewModel,
-          LoginUserDataAccessInterface userDataAccessObject)
-          throws IOException {
+      ViewManagerModel viewManagerModel,
+      LoginViewModel loginViewModel,
+      LoggedInViewModel loggedInViewModel,
+      LoginUserDataAccessInterface userDataAccessObject)
+      throws IOException {
 
     // Notice how we pass this method's parameters to the Presenter.
     LoginOutputBoundary loginOutputBoundary =
-            new LoginPresenter(viewManagerModel, loggedInViewModel, loginViewModel);
+        new LoginPresenter(viewManagerModel, loggedInViewModel, loginViewModel);
 
     UserFactory userFactory = new CommonUserFactory();
 
     LoginInputBoundary loginInteractor =
-            new LoginInteractor(userDataAccessObject, loginOutputBoundary);
+        new LoginInteractor(userDataAccessObject, loginOutputBoundary);
 
-    SwitchViewOutputBoundary switchViewOutputBoundary = (SwitchViewOutputBoundary) loginOutputBoundary;
+    SwitchViewOutputBoundary switchViewOutputBoundary =
+        (SwitchViewOutputBoundary) loginOutputBoundary;
     SwitchViewInputBoundary switchViewInteractor =
-            new SwitchViewInteractor(switchViewOutputBoundary);
+        new SwitchViewInteractor(switchViewOutputBoundary);
 
     return new LoginController(loginInteractor, switchViewInteractor);
   }

--- a/src/app/LoginUseCaseFactory.java
+++ b/src/app/LoginUseCaseFactory.java
@@ -13,6 +13,10 @@ import use_case.login.LoginInputBoundary;
 import use_case.login.LoginInteractor;
 import use_case.login.LoginOutputBoundary;
 import use_case.login.LoginUserDataAccessInterface;
+import use_case.switch_view.SwitchViewInputBoundary;
+import use_case.switch_view.SwitchViewInteractor;
+import use_case.switch_view.SwitchViewOutputBoundary;
+import use_case.switch_view.SwitchViewUserDataAccessInterface;
 import view.LoginView;
 
 public class LoginUseCaseFactory {
@@ -21,15 +25,15 @@ public class LoginUseCaseFactory {
   private LoginUseCaseFactory() {}
 
   public static LoginView create(
-      ViewManagerModel viewManagerModel,
-      LoginViewModel loginViewModel,
-      LoggedInViewModel loggedInViewModel,
-      LoginUserDataAccessInterface userDataAccessObject) {
+          ViewManagerModel viewManagerModel,
+          LoginViewModel loginViewModel,
+          LoggedInViewModel loggedInViewModel,
+          LoginUserDataAccessInterface userDataAccessObject) {
 
     try {
       LoginController loginController =
-          createLoginUseCase(
-              viewManagerModel, loginViewModel, loggedInViewModel, userDataAccessObject);
+              createLoginUseCase(
+                      viewManagerModel, loginViewModel, loggedInViewModel, userDataAccessObject);
       return new LoginView(loginViewModel, loginController);
     } catch (IOException e) {
       JOptionPane.showMessageDialog(null, "Could not open user data file.");
@@ -39,21 +43,25 @@ public class LoginUseCaseFactory {
   }
 
   private static LoginController createLoginUseCase(
-      ViewManagerModel viewManagerModel,
-      LoginViewModel loginViewModel,
-      LoggedInViewModel loggedInViewModel,
-      LoginUserDataAccessInterface userDataAccessObject)
-      throws IOException {
+          ViewManagerModel viewManagerModel,
+          LoginViewModel loginViewModel,
+          LoggedInViewModel loggedInViewModel,
+          LoginUserDataAccessInterface userDataAccessObject)
+          throws IOException {
 
     // Notice how we pass this method's parameters to the Presenter.
     LoginOutputBoundary loginOutputBoundary =
-        new LoginPresenter(viewManagerModel, loggedInViewModel, loginViewModel);
+            new LoginPresenter(viewManagerModel, loggedInViewModel, loginViewModel);
 
     UserFactory userFactory = new CommonUserFactory();
 
     LoginInputBoundary loginInteractor =
-        new LoginInteractor(userDataAccessObject, loginOutputBoundary);
+            new LoginInteractor(userDataAccessObject, loginOutputBoundary);
 
-    return new LoginController(loginInteractor);
+    SwitchViewOutputBoundary switchViewOutputBoundary = (SwitchViewOutputBoundary) loginOutputBoundary;
+    SwitchViewInputBoundary switchViewInteractor =
+            new SwitchViewInteractor(switchViewOutputBoundary);
+
+    return new LoginController(loginInteractor, switchViewInteractor);
   }
 }

--- a/src/interface_adapter/login/LoginController.java
+++ b/src/interface_adapter/login/LoginController.java
@@ -10,7 +10,8 @@ public class LoginController {
   final LoginInputBoundary loginUseCaseInteractor;
   private final SwitchViewInputBoundary switchViewInteractor;
 
-  public LoginController(LoginInputBoundary loginUseCaseInteractor, SwitchViewInputBoundary switchViewInteractor) {
+  public LoginController(
+      LoginInputBoundary loginUseCaseInteractor, SwitchViewInputBoundary switchViewInteractor) {
     this.loginUseCaseInteractor = loginUseCaseInteractor;
     this.switchViewInteractor = switchViewInteractor;
   }

--- a/src/interface_adapter/login/LoginController.java
+++ b/src/interface_adapter/login/LoginController.java
@@ -2,18 +2,26 @@ package interface_adapter.login;
 
 import use_case.login.LoginInputBoundary;
 import use_case.login.LoginInputData;
+import use_case.switch_view.SwitchViewInputBoundary;
+import use_case.switch_view.SwitchViewInputData;
 
 public class LoginController {
 
   final LoginInputBoundary loginUseCaseInteractor;
+  private final SwitchViewInputBoundary switchViewInteractor;
 
-  public LoginController(LoginInputBoundary loginUseCaseInteractor) {
+  public LoginController(LoginInputBoundary loginUseCaseInteractor, SwitchViewInputBoundary switchViewInteractor) {
     this.loginUseCaseInteractor = loginUseCaseInteractor;
+    this.switchViewInteractor = switchViewInteractor;
   }
 
   public void execute(String username, String password) {
     LoginInputData loginInputData = new LoginInputData(username, password);
 
     loginUseCaseInteractor.execute(loginInputData);
+  }
+
+  public void switchToSignup() {
+    switchViewInteractor.execute(new SwitchViewInputData("sign up"));
   }
 }

--- a/src/interface_adapter/login/LoginController.java
+++ b/src/interface_adapter/login/LoginController.java
@@ -2,27 +2,17 @@ package interface_adapter.login;
 
 import use_case.login.LoginInputBoundary;
 import use_case.login.LoginInputData;
-import use_case.switch_view.SwitchViewInputBoundary;
-import use_case.switch_view.SwitchViewInputData;
 
 public class LoginController {
 
   final LoginInputBoundary loginUseCaseInteractor;
-  private final SwitchViewInputBoundary switchViewInteractor;
 
-  public LoginController(
-      LoginInputBoundary loginUseCaseInteractor, SwitchViewInputBoundary switchViewInteractor) {
+  public LoginController(LoginInputBoundary loginUseCaseInteractor) {
     this.loginUseCaseInteractor = loginUseCaseInteractor;
-    this.switchViewInteractor = switchViewInteractor;
   }
 
   public void execute(String username, String password) {
     LoginInputData loginInputData = new LoginInputData(username, password);
-
     loginUseCaseInteractor.execute(loginInputData);
-  }
-
-  public void switchToSignup() {
-    switchViewInteractor.execute(new SwitchViewInputData("sign up"));
   }
 }

--- a/src/interface_adapter/login/LoginPresenter.java
+++ b/src/interface_adapter/login/LoginPresenter.java
@@ -5,17 +5,19 @@ import interface_adapter.logged_in.LoggedInState;
 import interface_adapter.logged_in.LoggedInViewModel;
 import use_case.login.LoginOutputBoundary;
 import use_case.login.LoginOutputData;
+import use_case.switch_view.SwitchViewOutputBoundary;
+import use_case.switch_view.SwitchViewOutputData;
 
-public class LoginPresenter implements LoginOutputBoundary {
+public class LoginPresenter implements LoginOutputBoundary, SwitchViewOutputBoundary {
 
   private final LoginViewModel loginViewModel;
   private final LoggedInViewModel loggedInViewModel;
   private final ViewManagerModel viewManagerModel;
 
   public LoginPresenter(
-      ViewManagerModel viewManagerModel,
-      LoggedInViewModel loggedInViewModel,
-      LoginViewModel loginViewModel) {
+          ViewManagerModel viewManagerModel,
+          LoggedInViewModel loggedInViewModel,
+          LoginViewModel loginViewModel) {
     this.viewManagerModel = viewManagerModel;
     this.loggedInViewModel = loggedInViewModel;
     this.loginViewModel = loginViewModel;
@@ -39,5 +41,12 @@ public class LoginPresenter implements LoginOutputBoundary {
     LoginState loginState = loginViewModel.getState();
     loginState.setUsernameError(error);
     loginViewModel.firePropertyChanged();
+  }
+
+  @Override
+  public void present(SwitchViewOutputData outputData) {
+    // Logic to handle view switching
+    this.viewManagerModel.setActiveView(outputData.getViewName());
+    this.viewManagerModel.firePropertyChanged();
   }
 }

--- a/src/interface_adapter/login/LoginPresenter.java
+++ b/src/interface_adapter/login/LoginPresenter.java
@@ -15,9 +15,9 @@ public class LoginPresenter implements LoginOutputBoundary, SwitchViewOutputBoun
   private final ViewManagerModel viewManagerModel;
 
   public LoginPresenter(
-          ViewManagerModel viewManagerModel,
-          LoggedInViewModel loggedInViewModel,
-          LoginViewModel loginViewModel) {
+      ViewManagerModel viewManagerModel,
+      LoggedInViewModel loggedInViewModel,
+      LoginViewModel loginViewModel) {
     this.viewManagerModel = viewManagerModel;
     this.loggedInViewModel = loggedInViewModel;
     this.loginViewModel = loginViewModel;

--- a/src/interface_adapter/switch_view/SwitchViewController.java
+++ b/src/interface_adapter/switch_view/SwitchViewController.java
@@ -1,0 +1,18 @@
+package interface_adapter.switch_view;
+
+import use_case.switch_view.SwitchViewInputBoundary;
+import use_case.switch_view.SwitchViewInputData;
+
+public class SwitchViewController {
+
+    private final SwitchViewInputBoundary switchViewInteractor;
+
+    public SwitchViewController(SwitchViewInputBoundary switchViewInteractor) {
+        this.switchViewInteractor = switchViewInteractor;
+    }
+
+    public void switchTo(String viewName) {
+        SwitchViewInputData switchViewInputData = new SwitchViewInputData(viewName);
+        switchViewInteractor.execute(switchViewInputData);
+    }
+}

--- a/src/interface_adapter/switch_view/SwitchViewController.java
+++ b/src/interface_adapter/switch_view/SwitchViewController.java
@@ -5,14 +5,14 @@ import use_case.switch_view.SwitchViewInputData;
 
 public class SwitchViewController {
 
-    private final SwitchViewInputBoundary switchViewInteractor;
+  private final SwitchViewInputBoundary switchViewInteractor;
 
-    public SwitchViewController(SwitchViewInputBoundary switchViewInteractor) {
-        this.switchViewInteractor = switchViewInteractor;
-    }
+  public SwitchViewController(SwitchViewInputBoundary switchViewInteractor) {
+    this.switchViewInteractor = switchViewInteractor;
+  }
 
-    public void switchTo(String viewName) {
-        SwitchViewInputData switchViewInputData = new SwitchViewInputData(viewName);
-        switchViewInteractor.execute(switchViewInputData);
-    }
+  public void switchTo(String viewName) {
+    SwitchViewInputData switchViewInputData = new SwitchViewInputData(viewName);
+    switchViewInteractor.execute(switchViewInputData);
+  }
 }

--- a/src/use_case/switch_view/SwitchViewInputBoundary.java
+++ b/src/use_case/switch_view/SwitchViewInputBoundary.java
@@ -1,5 +1,5 @@
 package use_case.switch_view;
 
 public interface SwitchViewInputBoundary {
-    void execute(SwitchViewInputData inputData);
+  void execute(SwitchViewInputData inputData);
 }

--- a/src/use_case/switch_view/SwitchViewInputBoundary.java
+++ b/src/use_case/switch_view/SwitchViewInputBoundary.java
@@ -1,0 +1,5 @@
+package use_case.switch_view;
+
+public interface SwitchViewInputBoundary {
+    void execute(SwitchViewInputData inputData);
+}

--- a/src/use_case/switch_view/SwitchViewInputData.java
+++ b/src/use_case/switch_view/SwitchViewInputData.java
@@ -1,13 +1,13 @@
 package use_case.switch_view;
 
 public class SwitchViewInputData {
-    private final String viewName;
+  private final String viewName;
 
-    public SwitchViewInputData(String viewName) {
-        this.viewName = viewName;
-    }
+  public SwitchViewInputData(String viewName) {
+    this.viewName = viewName;
+  }
 
-    public String getViewName() {
-        return viewName;
-    }
+  public String getViewName() {
+    return viewName;
+  }
 }

--- a/src/use_case/switch_view/SwitchViewInputData.java
+++ b/src/use_case/switch_view/SwitchViewInputData.java
@@ -1,0 +1,13 @@
+package use_case.switch_view;
+
+public class SwitchViewInputData {
+    private final String viewName;
+
+    public SwitchViewInputData(String viewName) {
+        this.viewName = viewName;
+    }
+
+    public String getViewName() {
+        return viewName;
+    }
+}

--- a/src/use_case/switch_view/SwitchViewInteractor.java
+++ b/src/use_case/switch_view/SwitchViewInteractor.java
@@ -1,0 +1,17 @@
+package use_case.switch_view;
+
+public class SwitchViewInteractor implements SwitchViewInputBoundary {
+    private final SwitchViewOutputBoundary outputBoundary;
+
+    public SwitchViewInteractor(SwitchViewOutputBoundary outputBoundary) {
+        this.outputBoundary = outputBoundary;
+    }
+
+    @Override
+    public void execute(SwitchViewInputData inputData) {
+        // Logic to switch views
+        // For example, sending the view name to the presenter
+        SwitchViewOutputData outputData = new SwitchViewOutputData(inputData.getViewName());
+        outputBoundary.present(outputData);
+    }
+}

--- a/src/use_case/switch_view/SwitchViewInteractor.java
+++ b/src/use_case/switch_view/SwitchViewInteractor.java
@@ -1,17 +1,17 @@
 package use_case.switch_view;
 
 public class SwitchViewInteractor implements SwitchViewInputBoundary {
-    private final SwitchViewOutputBoundary outputBoundary;
+  private final SwitchViewOutputBoundary outputBoundary;
 
-    public SwitchViewInteractor(SwitchViewOutputBoundary outputBoundary) {
-        this.outputBoundary = outputBoundary;
-    }
+  public SwitchViewInteractor(SwitchViewOutputBoundary outputBoundary) {
+    this.outputBoundary = outputBoundary;
+  }
 
-    @Override
-    public void execute(SwitchViewInputData inputData) {
-        // Logic to switch views
-        // For example, sending the view name to the presenter
-        SwitchViewOutputData outputData = new SwitchViewOutputData(inputData.getViewName());
-        outputBoundary.present(outputData);
-    }
+  @Override
+  public void execute(SwitchViewInputData inputData) {
+    // Logic to switch views
+    // For example, sending the view name to the presenter
+    SwitchViewOutputData outputData = new SwitchViewOutputData(inputData.getViewName());
+    outputBoundary.present(outputData);
+  }
 }

--- a/src/use_case/switch_view/SwitchViewOutputBoundary.java
+++ b/src/use_case/switch_view/SwitchViewOutputBoundary.java
@@ -1,5 +1,5 @@
 package use_case.switch_view;
 
 public interface SwitchViewOutputBoundary {
-    void present(SwitchViewOutputData outputData);
+  void present(SwitchViewOutputData outputData);
 }

--- a/src/use_case/switch_view/SwitchViewOutputBoundary.java
+++ b/src/use_case/switch_view/SwitchViewOutputBoundary.java
@@ -1,0 +1,5 @@
+package use_case.switch_view;
+
+public interface SwitchViewOutputBoundary {
+    void present(SwitchViewOutputData outputData);
+}

--- a/src/use_case/switch_view/SwitchViewOutputData.java
+++ b/src/use_case/switch_view/SwitchViewOutputData.java
@@ -1,13 +1,13 @@
 package use_case.switch_view;
 
 public class SwitchViewOutputData {
-    private final String viewName;
+  private final String viewName;
 
-    public SwitchViewOutputData(String viewName) {
-        this.viewName = viewName;
-    }
+  public SwitchViewOutputData(String viewName) {
+    this.viewName = viewName;
+  }
 
-    public String getViewName() {
-        return viewName;
-    }
+  public String getViewName() {
+    return viewName;
+  }
 }

--- a/src/use_case/switch_view/SwitchViewOutputData.java
+++ b/src/use_case/switch_view/SwitchViewOutputData.java
@@ -1,0 +1,13 @@
+package use_case.switch_view;
+
+public class SwitchViewOutputData {
+    private final String viewName;
+
+    public SwitchViewOutputData(String viewName) {
+        this.viewName = viewName;
+    }
+
+    public String getViewName() {
+        return viewName;
+    }
+}

--- a/src/use_case/switch_view/SwitchViewUserDataAccessInterface.java
+++ b/src/use_case/switch_view/SwitchViewUserDataAccessInterface.java
@@ -1,0 +1,5 @@
+package use_case.switch_view;
+
+public interface SwitchViewUserDataAccessInterface {
+    // Nothing needed here
+}

--- a/src/use_case/switch_view/SwitchViewUserDataAccessInterface.java
+++ b/src/use_case/switch_view/SwitchViewUserDataAccessInterface.java
@@ -1,5 +1,5 @@
 package use_case.switch_view;
 
 public interface SwitchViewUserDataAccessInterface {
-    // Nothing needed here
+  // Nothing needed here
 }

--- a/src/use_case/switch_view/SwitchViewUserDataAccessInterface.java
+++ b/src/use_case/switch_view/SwitchViewUserDataAccessInterface.java
@@ -1,5 +1,0 @@
-package use_case.switch_view;
-
-public interface SwitchViewUserDataAccessInterface {
-  // Nothing needed here
-}

--- a/src/view/LoginView.java
+++ b/src/view/LoginView.java
@@ -4,7 +4,6 @@ import interface_adapter.login.LoginController;
 import interface_adapter.login.LoginState;
 import interface_adapter.login.LoginViewModel;
 import interface_adapter.switch_view.SwitchViewController;
-
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -31,7 +30,10 @@ public class LoginView extends JPanel implements ActionListener, PropertyChangeL
   private final LoginController loginController;
   private final SwitchViewController switchViewController;
 
-  public LoginView(LoginViewModel loginViewModel, LoginController controller, SwitchViewController switchViewController) {
+  public LoginView(
+      LoginViewModel loginViewModel,
+      LoginController controller,
+      SwitchViewController switchViewController) {
 
     this.loginController = controller;
     this.loginViewModel = loginViewModel;
@@ -67,15 +69,14 @@ public class LoginView extends JPanel implements ActionListener, PropertyChangeL
     cancel.addActionListener(this);
 
     switchToSignup.addActionListener(
-          new ActionListener() {
-              @Override
-              public void actionPerformed(ActionEvent e) {
-                  switchViewController.switchTo("sign up");
-              }
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            switchViewController.switchTo("sign up");
           }
-    );
+        });
 
-  cancel.addActionListener(this);
+    cancel.addActionListener(this);
 
     usernameInputField.addKeyListener(
         new KeyListener() {

--- a/src/view/LoginView.java
+++ b/src/view/LoginView.java
@@ -3,6 +3,8 @@ package view;
 import interface_adapter.login.LoginController;
 import interface_adapter.login.LoginState;
 import interface_adapter.login.LoginViewModel;
+import interface_adapter.switch_view.SwitchViewController;
+
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -27,12 +29,14 @@ public class LoginView extends JPanel implements ActionListener, PropertyChangeL
   final JButton cancel;
   final JButton switchToSignup;
   private final LoginController loginController;
+  private final SwitchViewController switchViewController;
 
-  public LoginView(LoginViewModel loginViewModel, LoginController controller) {
+  public LoginView(LoginViewModel loginViewModel, LoginController controller, SwitchViewController switchViewController) {
 
     this.loginController = controller;
     this.loginViewModel = loginViewModel;
     this.loginViewModel.addPropertyChangeListener(this);
+    this.switchViewController = switchViewController;
 
     JLabel title = new JLabel("Login Screen");
     title.setAlignmentX(Component.CENTER_ALIGNMENT);
@@ -62,7 +66,16 @@ public class LoginView extends JPanel implements ActionListener, PropertyChangeL
 
     cancel.addActionListener(this);
 
-    switchToSignup.addActionListener(e -> loginController.switchToSignup());
+    switchToSignup.addActionListener(
+          new ActionListener() {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                  switchViewController.switchTo("sign up");
+              }
+          }
+    );
+
+  cancel.addActionListener(this);
 
     usernameInputField.addKeyListener(
         new KeyListener() {

--- a/src/view/LoginView.java
+++ b/src/view/LoginView.java
@@ -14,109 +14,109 @@ import javax.swing.*;
 
 public class LoginView extends JPanel implements ActionListener, PropertyChangeListener {
 
-    public final String viewName = "log in";
-    private final LoginViewModel loginViewModel;
+  public final String viewName = "log in";
+  private final LoginViewModel loginViewModel;
 
-    final JTextField usernameInputField = new JTextField(15);
-    private final JLabel usernameErrorField = new JLabel();
+  final JTextField usernameInputField = new JTextField(15);
+  private final JLabel usernameErrorField = new JLabel();
 
-    final JPasswordField passwordInputField = new JPasswordField(15);
-    private final JLabel passwordErrorField = new JLabel();
+  final JPasswordField passwordInputField = new JPasswordField(15);
+  private final JLabel passwordErrorField = new JLabel();
 
-    final JButton logIn;
-    final JButton cancel;
-    final JButton switchToSignup;
-    private final LoginController loginController;
+  final JButton logIn;
+  final JButton cancel;
+  final JButton switchToSignup;
+  private final LoginController loginController;
 
-    public LoginView(LoginViewModel loginViewModel, LoginController controller) {
+  public LoginView(LoginViewModel loginViewModel, LoginController controller) {
 
-        this.loginController = controller;
-        this.loginViewModel = loginViewModel;
-        this.loginViewModel.addPropertyChangeListener(this);
+    this.loginController = controller;
+    this.loginViewModel = loginViewModel;
+    this.loginViewModel.addPropertyChangeListener(this);
 
-        JLabel title = new JLabel("Login Screen");
-        title.setAlignmentX(Component.CENTER_ALIGNMENT);
+    JLabel title = new JLabel("Login Screen");
+    title.setAlignmentX(Component.CENTER_ALIGNMENT);
 
-        LabelTextPanel usernameInfo = new LabelTextPanel(new JLabel("Username"), usernameInputField);
-        LabelTextPanel passwordInfo = new LabelTextPanel(new JLabel("Password"), passwordInputField);
+    LabelTextPanel usernameInfo = new LabelTextPanel(new JLabel("Username"), usernameInputField);
+    LabelTextPanel passwordInfo = new LabelTextPanel(new JLabel("Password"), passwordInputField);
 
-        JPanel buttons = new JPanel();
-        logIn = new JButton(LoginViewModel.LOGIN_BUTTON_LABEL);
-        buttons.add(logIn);
-        cancel = new JButton(LoginViewModel.CANCEL_BUTTON_LABEL);
-        buttons.add(cancel);
-        switchToSignup = new JButton("Sign Up");
-        buttons.add(switchToSignup);
+    JPanel buttons = new JPanel();
+    logIn = new JButton(LoginViewModel.LOGIN_BUTTON_LABEL);
+    buttons.add(logIn);
+    cancel = new JButton(LoginViewModel.CANCEL_BUTTON_LABEL);
+    buttons.add(cancel);
+    switchToSignup = new JButton("Sign Up");
+    buttons.add(switchToSignup);
 
-        logIn.addActionListener(
-                // This creates an anonymous subclass of ActionListener and instantiates it.
-                new ActionListener() {
-                    public void actionPerformed(ActionEvent evt) {
-                        if (evt.getSource().equals(logIn)) {
-                            LoginState currentState = loginViewModel.getState();
+    logIn.addActionListener(
+        // This creates an anonymous subclass of ActionListener and instantiates it.
+        new ActionListener() {
+          public void actionPerformed(ActionEvent evt) {
+            if (evt.getSource().equals(logIn)) {
+              LoginState currentState = loginViewModel.getState();
 
-                            loginController.execute(currentState.getUsername(), currentState.getPassword());
-                        }
-                    }
-                });
+              loginController.execute(currentState.getUsername(), currentState.getPassword());
+            }
+          }
+        });
 
-        cancel.addActionListener(this);
+    cancel.addActionListener(this);
 
-        switchToSignup.addActionListener(e -> loginController.switchToSignup());
+    switchToSignup.addActionListener(e -> loginController.switchToSignup());
 
-        usernameInputField.addKeyListener(
-                new KeyListener() {
-                    @Override
-                    public void keyTyped(KeyEvent e) {
-                        LoginState currentState = loginViewModel.getState();
-                        currentState.setUsername(usernameInputField.getText() + e.getKeyChar());
-                        loginViewModel.setState(currentState);
-                    }
+    usernameInputField.addKeyListener(
+        new KeyListener() {
+          @Override
+          public void keyTyped(KeyEvent e) {
+            LoginState currentState = loginViewModel.getState();
+            currentState.setUsername(usernameInputField.getText() + e.getKeyChar());
+            loginViewModel.setState(currentState);
+          }
 
-                    @Override
-                    public void keyPressed(KeyEvent e) {}
+          @Override
+          public void keyPressed(KeyEvent e) {}
 
-                    @Override
-                    public void keyReleased(KeyEvent e) {}
-                });
-        this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+          @Override
+          public void keyReleased(KeyEvent e) {}
+        });
+    this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
-        passwordInputField.addKeyListener(
-                new KeyListener() {
-                    @Override
-                    public void keyTyped(KeyEvent e) {
-                        LoginState currentState = loginViewModel.getState();
-                        currentState.setPassword(passwordInputField.getText() + e.getKeyChar());
-                        loginViewModel.setState(currentState);
-                    }
+    passwordInputField.addKeyListener(
+        new KeyListener() {
+          @Override
+          public void keyTyped(KeyEvent e) {
+            LoginState currentState = loginViewModel.getState();
+            currentState.setPassword(passwordInputField.getText() + e.getKeyChar());
+            loginViewModel.setState(currentState);
+          }
 
-                    @Override
-                    public void keyPressed(KeyEvent e) {}
+          @Override
+          public void keyPressed(KeyEvent e) {}
 
-                    @Override
-                    public void keyReleased(KeyEvent e) {}
-                });
+          @Override
+          public void keyReleased(KeyEvent e) {}
+        });
 
-        this.add(title);
-        this.add(usernameInfo);
-        this.add(usernameErrorField);
-        this.add(passwordInfo);
-        this.add(passwordErrorField);
-        this.add(buttons);
-    }
+    this.add(title);
+    this.add(usernameInfo);
+    this.add(usernameErrorField);
+    this.add(passwordInfo);
+    this.add(passwordErrorField);
+    this.add(buttons);
+  }
 
-    /** React to a button click that results in evt. */
-    public void actionPerformed(ActionEvent evt) {
-        System.out.println("Click " + evt.getActionCommand());
-    }
+  /** React to a button click that results in evt. */
+  public void actionPerformed(ActionEvent evt) {
+    System.out.println("Click " + evt.getActionCommand());
+  }
 
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        LoginState state = (LoginState) evt.getNewValue();
-        setFields(state);
-    }
+  @Override
+  public void propertyChange(PropertyChangeEvent evt) {
+    LoginState state = (LoginState) evt.getNewValue();
+    setFields(state);
+  }
 
-    private void setFields(LoginState state) {
-        usernameInputField.setText(state.getUsername());
-    }
+  private void setFields(LoginState state) {
+    usernameInputField.setText(state.getUsername());
+  }
 }

--- a/src/view/LoginView.java
+++ b/src/view/LoginView.java
@@ -14,104 +14,109 @@ import javax.swing.*;
 
 public class LoginView extends JPanel implements ActionListener, PropertyChangeListener {
 
-  public final String viewName = "log in";
-  private final LoginViewModel loginViewModel;
+    public final String viewName = "log in";
+    private final LoginViewModel loginViewModel;
 
-  final JTextField usernameInputField = new JTextField(15);
-  private final JLabel usernameErrorField = new JLabel();
+    final JTextField usernameInputField = new JTextField(15);
+    private final JLabel usernameErrorField = new JLabel();
 
-  final JPasswordField passwordInputField = new JPasswordField(15);
-  private final JLabel passwordErrorField = new JLabel();
+    final JPasswordField passwordInputField = new JPasswordField(15);
+    private final JLabel passwordErrorField = new JLabel();
 
-  final JButton logIn;
-  final JButton cancel;
-  private final LoginController loginController;
+    final JButton logIn;
+    final JButton cancel;
+    final JButton switchToSignup;
+    private final LoginController loginController;
 
-  public LoginView(LoginViewModel loginViewModel, LoginController controller) {
+    public LoginView(LoginViewModel loginViewModel, LoginController controller) {
 
-    this.loginController = controller;
-    this.loginViewModel = loginViewModel;
-    this.loginViewModel.addPropertyChangeListener(this);
+        this.loginController = controller;
+        this.loginViewModel = loginViewModel;
+        this.loginViewModel.addPropertyChangeListener(this);
 
-    JLabel title = new JLabel("Login Screen");
-    title.setAlignmentX(Component.CENTER_ALIGNMENT);
+        JLabel title = new JLabel("Login Screen");
+        title.setAlignmentX(Component.CENTER_ALIGNMENT);
 
-    LabelTextPanel usernameInfo = new LabelTextPanel(new JLabel("Username"), usernameInputField);
-    LabelTextPanel passwordInfo = new LabelTextPanel(new JLabel("Password"), passwordInputField);
+        LabelTextPanel usernameInfo = new LabelTextPanel(new JLabel("Username"), usernameInputField);
+        LabelTextPanel passwordInfo = new LabelTextPanel(new JLabel("Password"), passwordInputField);
 
-    JPanel buttons = new JPanel();
-    logIn = new JButton(LoginViewModel.LOGIN_BUTTON_LABEL);
-    buttons.add(logIn);
-    cancel = new JButton(LoginViewModel.CANCEL_BUTTON_LABEL);
-    buttons.add(cancel);
+        JPanel buttons = new JPanel();
+        logIn = new JButton(LoginViewModel.LOGIN_BUTTON_LABEL);
+        buttons.add(logIn);
+        cancel = new JButton(LoginViewModel.CANCEL_BUTTON_LABEL);
+        buttons.add(cancel);
+        switchToSignup = new JButton("Sign Up");
+        buttons.add(switchToSignup);
 
-    logIn.addActionListener(
-        // This creates an anonymous subclass of ActionListener and instantiates it.
-        new ActionListener() {
-          public void actionPerformed(ActionEvent evt) {
-            if (evt.getSource().equals(logIn)) {
-              LoginState currentState = loginViewModel.getState();
+        logIn.addActionListener(
+                // This creates an anonymous subclass of ActionListener and instantiates it.
+                new ActionListener() {
+                    public void actionPerformed(ActionEvent evt) {
+                        if (evt.getSource().equals(logIn)) {
+                            LoginState currentState = loginViewModel.getState();
 
-              loginController.execute(currentState.getUsername(), currentState.getPassword());
-            }
-          }
-        });
+                            loginController.execute(currentState.getUsername(), currentState.getPassword());
+                        }
+                    }
+                });
 
-    cancel.addActionListener(this);
+        cancel.addActionListener(this);
 
-    usernameInputField.addKeyListener(
-        new KeyListener() {
-          @Override
-          public void keyTyped(KeyEvent e) {
-            LoginState currentState = loginViewModel.getState();
-            currentState.setUsername(usernameInputField.getText() + e.getKeyChar());
-            loginViewModel.setState(currentState);
-          }
+        switchToSignup.addActionListener(e -> loginController.switchToSignup());
 
-          @Override
-          public void keyPressed(KeyEvent e) {}
+        usernameInputField.addKeyListener(
+                new KeyListener() {
+                    @Override
+                    public void keyTyped(KeyEvent e) {
+                        LoginState currentState = loginViewModel.getState();
+                        currentState.setUsername(usernameInputField.getText() + e.getKeyChar());
+                        loginViewModel.setState(currentState);
+                    }
 
-          @Override
-          public void keyReleased(KeyEvent e) {}
-        });
-    this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+                    @Override
+                    public void keyPressed(KeyEvent e) {}
 
-    passwordInputField.addKeyListener(
-        new KeyListener() {
-          @Override
-          public void keyTyped(KeyEvent e) {
-            LoginState currentState = loginViewModel.getState();
-            currentState.setPassword(passwordInputField.getText() + e.getKeyChar());
-            loginViewModel.setState(currentState);
-          }
+                    @Override
+                    public void keyReleased(KeyEvent e) {}
+                });
+        this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
-          @Override
-          public void keyPressed(KeyEvent e) {}
+        passwordInputField.addKeyListener(
+                new KeyListener() {
+                    @Override
+                    public void keyTyped(KeyEvent e) {
+                        LoginState currentState = loginViewModel.getState();
+                        currentState.setPassword(passwordInputField.getText() + e.getKeyChar());
+                        loginViewModel.setState(currentState);
+                    }
 
-          @Override
-          public void keyReleased(KeyEvent e) {}
-        });
+                    @Override
+                    public void keyPressed(KeyEvent e) {}
 
-    this.add(title);
-    this.add(usernameInfo);
-    this.add(usernameErrorField);
-    this.add(passwordInfo);
-    this.add(passwordErrorField);
-    this.add(buttons);
-  }
+                    @Override
+                    public void keyReleased(KeyEvent e) {}
+                });
 
-  /** React to a button click that results in evt. */
-  public void actionPerformed(ActionEvent evt) {
-    System.out.println("Click " + evt.getActionCommand());
-  }
+        this.add(title);
+        this.add(usernameInfo);
+        this.add(usernameErrorField);
+        this.add(passwordInfo);
+        this.add(passwordErrorField);
+        this.add(buttons);
+    }
 
-  @Override
-  public void propertyChange(PropertyChangeEvent evt) {
-    LoginState state = (LoginState) evt.getNewValue();
-    setFields(state);
-  }
+    /** React to a button click that results in evt. */
+    public void actionPerformed(ActionEvent evt) {
+        System.out.println("Click " + evt.getActionCommand());
+    }
 
-  private void setFields(LoginState state) {
-    usernameInputField.setText(state.getUsername());
-  }
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        LoginState state = (LoginState) evt.getNewValue();
+        setFields(state);
+    }
+
+    private void setFields(LoginState state) {
+        usernameInputField.setText(state.getUsername());
+    }
 }

--- a/src/view/LoginView.java
+++ b/src/view/LoginView.java
@@ -76,8 +76,6 @@ public class LoginView extends JPanel implements ActionListener, PropertyChangeL
           }
         });
 
-    cancel.addActionListener(this);
-
     usernameInputField.addKeyListener(
         new KeyListener() {
           @Override


### PR DESCRIPTION
Switch to signup page from login page using a new `switch_view` use case interactor. One potential issue is that after a user makes an account, if they click the switch to signup button on the login page, they will be presented with the information they already filled in. This is probably good for when we switch from the signup page to the login page if the user was on the login page previously, but we should get rid of it in the login page to signup page case. I'm holding off on it now because it's better to implement this after we have a signup page to login page button.